### PR TITLE
Add support for encrypted CLT files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ BFForever is an open-source library for managing and creating game files from th
 # Currently Implemented
 * XRP2 (~50% WIP)
 * CELT
-  * Decoding (Decrypted-Only)
+  * Decoding
 * RIFF (Read Only)
   * Audio
   * AudioEffect


### PR DESCRIPTION
It's as simple as decrypting all the audio data with a fixed 256-bit key in ECB mode.